### PR TITLE
ci: fix secrets context in package-ci

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -39,6 +39,8 @@ jobs:
   publish-testpypi:
     runs-on: ubuntu-latest
     needs: build
+  env:
+      TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -46,17 +48,19 @@ jobs:
           name: cflow-platform-dist
           path: dist
       - name: Publish to TestPyPI
-        if: ${{ secrets.TEST_PYPI_TOKEN != '' }}
+        if: ${{ env.TEST_PYPI_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          password: ${{ env.TEST_PYPI_TOKEN }}
           packages-dir: dist
 
   publish-pypi:
     runs-on: ubuntu-latest
     needs: build
+  env:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -64,9 +68,9 @@ jobs:
           name: cflow-platform-dist
           path: dist
       - name: Publish to PyPI
-        if: ${{ secrets.PYPI_TOKEN != '' }}
+        if: ${{ env.PYPI_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ env.PYPI_TOKEN }}
           packages-dir: dist


### PR DESCRIPTION
Map secrets to job env and gate publish steps with env vars; add workflow_dispatch.