### PR TITLE
chore(ci): auto-enable auto-merge on label

### DIFF
--- a/.github/workflows/auto-enable-auto-merge.yml
+++ b/.github/workflows/auto-enable-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Auto-enable auto-merge on labeled PRs
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  enable_auto_merge:
+    if: github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --squash --auto
+

--- a/cflow_platform/core/direct_client.py
+++ b/cflow_platform/core/direct_client.py
@@ -110,7 +110,7 @@ async def execute_mcp_tool(tool_name: str, **kwargs: Any) -> Dict[str, Any]:
         return await mapping[tool_name](kwargs or {})
     if tool_name in {"sys_stats", "sys_debug", "sys_version"}:
         mod = load_handler_module("system_handlers")
-        tm = TaskManagerAdapter()
+        tm = TaskManagerClient()
         handler = mod.SystemHandlers(task_manager=tm, project_root=Path.cwd())  # type: ignore[attr-defined]
         if tool_name == "sys_stats":
             return await handler.handle_get_stats(kwargs or {})

--- a/cflow_platform/core/tool_registry.py
+++ b/cflow_platform/core/tool_registry.py
@@ -96,12 +96,9 @@ class ToolRegistry:
 
         return tools
 
-from typing import Any, Dict
-
-
-class ToolRegistry:
     @staticmethod
     def get_version_info() -> Dict[str, Any]:
+        total = len(ToolRegistry.get_tools_for_mcp())
         return {
             "mcp_server_version": "1.0.0",
             "api_version": "1.0.0",
@@ -109,7 +106,7 @@ class ToolRegistry:
             "next_version": "2.0.0",
             "deprecation_date": "2025-12-31T23:59:59Z",
             "versioning_standard": "CEREBRAL_191_INTEGRATION_API_VERSIONING_STANDARDS.md",
-            "total_tools": 0,
+            "total_tools": total,
             "version_metadata": {
                 "semantic_versioning": True,
                 "backward_compatibility": True,


### PR DESCRIPTION
Adds a workflow to enable auto-merge (squash) automatically when a PR is labeled 'auto-merge'.